### PR TITLE
Update to instrument Mongo::Networking

### DIFF
--- a/lib/mongo/rails/instrumentation/railtie.rb
+++ b/lib/mongo/rails/instrumentation/railtie.rb
@@ -5,7 +5,7 @@ module Mongo::Rails::Instrumentation
     initializer "mongo.rails.instrumentation" do |app|
       instrument Mongo::Networking, [
         :send_message,
-        :send_message_with_safe_check,
+        :send_message_with_gle,
         :receive_message
       ]
 

--- a/lib/mongo/rails/instrumentation/railtie.rb
+++ b/lib/mongo/rails/instrumentation/railtie.rb
@@ -3,7 +3,7 @@ require 'mongo/rails/instrumentation'
 module Mongo::Rails::Instrumentation
   class Railtie < Rails::Railtie
     initializer "mongo.rails.instrumentation" do |app|
-      instrument Mongo::Connection, [
+      instrument Mongo::Networking, [
         :send_message,
         :send_message_with_safe_check,
         :receive_message


### PR DESCRIPTION
Newer Mongo drivers rename Connection to Client, and Mongo::Networking
has been around since Nov 2011.
